### PR TITLE
Add  authenticated endpoint for getting current user account.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const auth = jwt({
 // to reuse the connection pool in your app.
 // Connect to the database before starting the application server.
 const connString = process.env.MONGO_URI;
-exports.connect = () =>
+exports.connect = (connPort = 8080) =>
   mongodb.MongoClient.connect(connString)
     .then((db) => {
       // Save database object from the callback for reuse.
@@ -76,7 +76,7 @@ exports.connect = () =>
       // Routes
       app.use('/api', routes(db, auth));
 
-      const server = app.listen(process.env.PORT || 8080, () => {
+      const server = app.listen(process.env.PORT || connPort, () => {
         const port = server.address().port;
         console.log('App now running on port', port);
       });

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,7 +12,7 @@ module.exports = (db, auth) => {
   // -------------- PINS API BELOW -------------------------------
   router.use('/pins', pins(db, auth));
   // -------------- ACCOUNT API BELOW -------------------------
-  router.use('/accounts', accounts(db));
+  router.use('/accounts', accounts(db, auth));
   // -------------- TRIPS API BELOW -------------------------
   router.use('/trips', trips(db));
 

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -8,4 +8,57 @@ const expect = chai.expect;
 require('dotenv').config();
 const server = require('../index');
 
-describe('Accounts', () => {});
+describe('Accounts', () => {
+  let app;
+  let db;
+  let pins;
+  let accounts;
+  before(() => server.connect(5001).then((res) => {
+    app = res.app;
+    db = res.db;
+    pins = db.collection('pins');
+    accounts = db.collection('accounts');
+    return db;
+  }));
+
+  // reset db
+  afterEach(() => pins.deleteMany());
+  afterEach(() => accounts.deleteMany());
+
+  describe('GET Accounts', () => {
+    it('should create a new user account if none exists', () =>
+      chai.request(app)
+        .get('/api/accounts/currentuser')
+        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .then((res) => {
+          expect(res).to.have.status(200);
+          const account = res.body;
+          expect(account.createDate).to.be.not.empty;
+          expect(account.numSeeds).to.equal(0);
+          expect(account.numPins).to.equal(0);
+        })
+        .catch((err) => {
+          throw err;
+        }));
+    it('should find an existing user account', () =>
+      accounts.insertOne({
+        auth0Id: process.env.TEST_USER_SUB,
+        createDate: new Date(),
+        numSeeds: 10,
+        numPins: 5,
+      }).then(res => res.ops[0]).then(acct =>
+        chai.request(app)
+          .get('/api/accounts/currentuser')
+          .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+          .then((res) => {
+            expect(res).to.have.status(200);
+            const account = res.body;
+            expect(new Date(account.createDate)).to.eql(acct.createDate);
+            expect(account.numSeeds).to.equal(acct.numSeeds);
+            expect(account.numPins).to.equal(acct.numPins);
+          })
+      ).catch((err) => {
+        throw err;
+      }));
+  });
+});

--- a/test/pins.js
+++ b/test/pins.js
@@ -23,7 +23,7 @@ describe('Pins', () => {
   let db;
   let pins;
   let accounts;
-  before(() => server.connect().then((res) => {
+  before(() => server.connect(5000).then((res) => {
     app = res.app;
     db = res.db;
     pins = db.collection('pins');
@@ -32,7 +32,8 @@ describe('Pins', () => {
   }));
 
   // reset db
-  beforeEach(() => pins.deleteMany());
+  afterEach(() => pins.deleteMany());
+  afterEach(() => accounts.deleteMany());
 
   describe('GET pins', () => {
     beforeEach(() => pins.insertMany(getPins()));


### PR DESCRIPTION
`GET /accounts/currentuser` will create a new database user account on first sign in (i.e. we do not have a daytomato account for a user). This ensures grabbing user profile data for the home/profile view only requires one api call.