### PR TITLE
Mock auth to re-enable tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.13.3",
     "express-jwt": "^5.1.0",
     "google-auth-library": "^0.9.9",
+    "jsonwebtoken": "^7.2.1",
     "mongodb": "^2.1.6"
   },
   "devDependencies": {

--- a/routes/pins.js
+++ b/routes/pins.js
@@ -96,7 +96,7 @@ module.exports = (db, auth) => {
 
     if (!req.body.expireAt) {
       // Default expiration time, means never ending event (such as a park)
-      // newPin.expireAt = null;
+      newPin.expireAt = null;
     } else {
       // set date and time for expiration. example : "2016-11-20T22:00:00.000Z"
       newPin.expireAt = new Date(req.body.expireAt);

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -6,6 +6,8 @@ const expect = chai.expect;
 
 // Set up env vars
 require('dotenv').config();
+
+const { TEST_JWT } = require('./auth_bootstrap');
 const server = require('../index');
 
 describe('Accounts', () => {
@@ -29,7 +31,7 @@ describe('Accounts', () => {
     it('should create a new user account if none exists', () =>
       chai.request(app)
         .get('/api/accounts/currentuser')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .then((res) => {
           expect(res).to.have.status(200);
           const account = res.body;
@@ -51,7 +53,7 @@ describe('Accounts', () => {
       }).then(res => res.ops[0]).then(acct =>
         chai.request(app)
           .get('/api/accounts/currentuser')
-          .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+          .set('Authorization', `Bearer ${TEST_JWT}`)
           .then((res) => {
             expect(res).to.have.status(200);
             const account = res.body;

--- a/test/auth_bootstrap.js
+++ b/test/auth_bootstrap.js
@@ -1,0 +1,29 @@
+const jwt = require('jsonwebtoken');
+const OAuth2Client = require('google-auth-library/lib/auth/oauth2client');
+
+const kid = 'asdf-1234-qwerty-56789';
+const authConf = {
+  privKey: '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA4hhVnwXfvuNxz8x6chxi/euacpyjWXqWCF4sLIziLH/yRURu\nDPn2b9UH2RgfzzZCyfe+1rSCOmhsh3WmZ2gjiJyMbHXxD0/1biz/eHptJ2ytAG8B\nVk0jppdiFkdifEFhuDk8YcMuYABNxlgq7/55MK3hnlyGlOO4uDTIkG77AYOD5T/p\ncPLskp5TGAkaaNHGOn9g8XfhfBB7wJ67AtLmxCc3aC9ItTXofkogoKKXM/qpbhvR\n6QH0pldlRKIt1V+H/36TJZ74SvhjQWaUK0XMybe3Cc/HZ1yMzzgeheyRmrzzf4Wi\nHFG2/b53wtlfvcKicTe9COwSpo33p05Bd6Pb7wIDAQABAoIBAGpJmE62uzWIxOM0\nNEfasmq+TJAetOgGqetrIgcbf+P9jg4kGjw9ci2mjxbusV1/G6zIq81RdHsyxfp0\nQ3MPUM0TEyyV0WoqY62Ut9CSdSf4fefbR1yjzOOu/OyOSG0za1XoiktHL1DwM5/P\nqPfDwIMy6wLAaoAqAZePMM49bgCKSb1oxqIIlEL1T7grs040t0wpoMsDGCt5zvft\nkqnZIQkfu7K2Lp3z93DN+dSWiaG/fu0EURsmMhDuxaLER1G/SX8nXHgUTpfTJzFA\naP6ez+Bl4sM1PhJVuM8y17Kd8TwDf7xCtUmn7HykAAu7I1Q2fKUv7Aya7qhiGRWI\nThtRyCECgYEA9osdT3xE9WqgH8bfM56JaEOTA4Pb266EnSDy3oQ4gCSrQlDKaGzV\n6DHFMnr/siPqsImug+Y2rBsuS1thmjLvU2aR0f+HmUSVe7uGLqcG/YvVecmOaLJ0\nC2sRQC7W5ZZlUypPnVgfxpa/sZ1/ZI6nRRl1xV+YaU2TiJM1gz1mhF8CgYEA6sRu\nZeqdgrsP5uBLplglgWmxAQP7q0bvwGWVyXidJvaxGtpwNQta8iROql87qKCK8ZWN\nr1VaNYws9dYO/p/VHHBNUc0RV2VdATH5ErCLKuIAffAUSjYTz+XUO9lJEwK3RJnC\nO5q/KX2Vg9C4W3Xi/utIrNlJutG/QGAOglIjUnECgYEAmcpDmV6KYZCGm+vhNYDy\nc9CbNzkcf1fIr39rILTXzc+R6Qcei69Aa9wIB6pEMCpJbqAj9XE4r3kxEp7JLngR\nZDP6SEWen1Px70IVvKpCKQz+OD8rj1GqI6lBFIljUcnUIOGm0h6zi5xjrXbyjZaS\n7v6nwVwVZbKXkj1JxzkY5v8CgYBdJ8a6sCcCGeIMddHu1qlDOcIfqgnyA7rcuDKA\neFi7fkX2ZtkBY1kaHigM2K8ekV2w0Owgt5iNCOtKPT9D7/4rQ7CalemcqT8HW2H+\n9YizYmxZjKswa1bfNs5JVUX2wiwgj3aQGi5ic0+ht29/8z44cvoqhCoKdHIUREld\nkuQrMQKBgQDQffVIN3PiS24HHtzey9vLNn5VzNbdLVXBY2u8BAdK2KQfQx44pkj2\nR5UlGbnT0C+vmKd2i+sDUaZl3V4NFzByS7PmYsiFt4wIxld19Dq2lI8DYi2oRrh7\nSnS0htpnTERCW1p2EW19u3zQ3BLquvy0OKZ2Ja/UyEFAHs+hEMjgyw==\n-----END RSA PRIVATE KEY-----\n',
+  certs: {
+    [kid]: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4hhVnwXfvuNxz8x6chxi\n/euacpyjWXqWCF4sLIziLH/yRURuDPn2b9UH2RgfzzZCyfe+1rSCOmhsh3WmZ2gj\niJyMbHXxD0/1biz/eHptJ2ytAG8BVk0jppdiFkdifEFhuDk8YcMuYABNxlgq7/55\nMK3hnlyGlOO4uDTIkG77AYOD5T/pcPLskp5TGAkaaNHGOn9g8XfhfBB7wJ67AtLm\nxCc3aC9ItTXofkogoKKXM/qpbhvR6QH0pldlRKIt1V+H/36TJZ74SvhjQWaUK0XM\nybe3Cc/HZ1yMzzgeheyRmrzzf4WiHFG2/b53wtlfvcKicTe9COwSpo33p05Bd6Pb\n7wIDAQAB\n-----END PUBLIC KEY-----\n',
+  },
+};
+
+// Patch OAuth client to use our own test certs
+// FIXME is there a better way to do this?
+Object.assign(OAuth2Client.prototype, {
+  getFederatedSignonCerts(cb) {
+    cb(null, authConf.certs);
+  },
+});
+
+exports.TEST_JWT = jwt.sign({
+  name: 'TestUser',
+}, authConf.privKey, {
+  algorithm: 'RS256',
+  expiresIn: '1h',
+  keyid: kid,
+  issuer: 'accounts.google.com',
+  subject: process.env.TEST_USER_SUB,
+  audience: process.env.AUTH_AUDIENCE,
+});

--- a/test/pins.js
+++ b/test/pins.js
@@ -6,6 +6,8 @@ const expect = chai.expect;
 
 // Set up env vars
 require('dotenv').config();
+
+const { TEST_JWT } = require('./auth_bootstrap');
 const server = require('../index');
 
 function getPins() {
@@ -42,7 +44,7 @@ describe('Pins', () => {
     it('should get all the pins', () =>
       chai.request(app)
         .get('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .then((res) => {
           expect(res).to.have.status(200);
           expect(res.body).to.be.a('array');
@@ -54,7 +56,7 @@ describe('Pins', () => {
     it('should get a limited number of pins', () =>
       chai.request(app)
         .get('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .query({ limit: 5 })
         .then((res) => {
           expect(res).to.have.status(200);
@@ -68,7 +70,7 @@ describe('Pins', () => {
     it('should sort pins by name', () =>
       chai.request(app)
         .get('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .query({ sort: 'name' })
         .then((res) => {
           expect(res).to.have.status(200);
@@ -84,7 +86,7 @@ describe('Pins', () => {
     it('should filter pins by cost', () =>
       chai.request(app)
         .get('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .query({ cost: '20,30' })
         .then((res) => {
           expect(res).to.have.status(200);
@@ -99,7 +101,7 @@ describe('Pins', () => {
     it('should filter pins by coordinates', () =>
       chai.request(app)
         .get('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .query({ searchArea: [50, 50, 0, 0].join() })
         .then((res) => {
           expect(res).to.have.status(200);
@@ -114,7 +116,7 @@ describe('Pins', () => {
     it('should set default property values', () =>
       chai.request(app)
         .post('/api/pins')
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .send({ name: 'Test1' })
         .then((res) => {
           expect(res).to.have.status(201);
@@ -144,7 +146,7 @@ describe('Pins', () => {
     it('should update a particular pin', () =>
       chai.request(app)
         .put(`/api/pins/${inserted._id}`)
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .send({
           name: 'Updated',
           cost: 11.0,
@@ -175,7 +177,7 @@ describe('Pins', () => {
     it('should update a particular pin', () =>
       chai.request(app)
         .delete(`/api/pins/${inserted._id}`)
-        .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+        .set('Authorization', `Bearer ${TEST_JWT}`)
         .then((res) => {
           expect(res).to.have.status(204);
           return pins.count().then((count) => {
@@ -210,7 +212,7 @@ describe('Pins', () => {
       it('should add likes to a pin', () =>
         chai.request(app)
           .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-          .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+          .set('Authorization', `Bearer ${TEST_JWT}`)
           .send({ dir: 1 })
           .then((res) => {
             expect(res).to.have.status(204);
@@ -232,7 +234,7 @@ describe('Pins', () => {
         }).then(_ =>
           chai.request(app)
             .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-            .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+            .set('Authorization', `Bearer ${TEST_JWT}`)
             .send({ dir: 1 })
         ).catch((err) => {
           expect(err.response).to.have.status(409);
@@ -245,7 +247,7 @@ describe('Pins', () => {
         }).then(_ =>
           chai.request(app)
             .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-            .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+            .set('Authorization', `Bearer ${TEST_JWT}`)
             .send({ dir: 0 })
         ).then((res) => {
           expect(res).to.have.status(204);
@@ -263,7 +265,7 @@ describe('Pins', () => {
       it('should add dislikes to a pin', () =>
         chai.request(app)
           .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-          .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+          .set('Authorization', `Bearer ${TEST_JWT}`)
           .send({ dir: -1 })
           .then((res) => {
             expect(res).to.have.status(204);
@@ -285,7 +287,7 @@ describe('Pins', () => {
         }).then(_ =>
           chai.request(app)
             .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-            .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+            .set('Authorization', `Bearer ${TEST_JWT}`)
             .send({ dir: -1 })
         ).catch((err) => {
           expect(err.response).to.have.status(409);
@@ -298,7 +300,7 @@ describe('Pins', () => {
         }).then(_ =>
           chai.request(app)
             .put(`/api/pins/${inserted._id}/votes/${account._id}`)
-            .set('Authorization', `Bearer ${process.env.TEST_JWT}`)
+            .set('Authorization', `Bearer ${TEST_JWT}`)
             .send({ dir: 0 })
         ).then((res) => {
           expect(res).to.have.status(204);


### PR DESCRIPTION
By monkey-patching the default google id token verifier's certificate-finding mechanism, we can finally use test credentials again. It's about time!